### PR TITLE
Remove PEP 594-related modules ("dead batteries")

### DIFF
--- a/Setup.local
+++ b/Setup.local
@@ -24,12 +24,9 @@ _statistics _statisticsmodule.c
 fcntl fcntlmodule.c
 pwd pwdmodule.c
 grp grpmodule.c
-spwd spwdmodule.c
 select selectmodule.c
-parser parsermodule.c
 mmap mmapmodule.c
 syslog syslogmodule.c
-audioop audioop.c -lm
 _csv _csv.c
 _posixsubprocess _posixsubprocess.c
 _testcapi _testcapimodule.c -UPy_BUILD_CORE -UPy_BUILD_CORE_BUILTIN
@@ -38,10 +35,9 @@ _testbuffer _testbuffer.c
 _testimportmultiple _testimportmultiple.c
 _testmultiphase _testmultiphase.c
 _xxtestfuzz _xxtestfuzz/_xxtestfuzz.c _xxtestfuzz/fuzzer.c
-readline readline.c -lreadline -L/usr/lib/termcap -lreadline -ltinfo -ltinfo
+readline readline.c -lreadline -L/usr/lib/termcap
 _curses _cursesmodule.c -I/usr/include/ncursesw -DHAVE_NCURSESW -lncursesw -lncursesw -ltinfo -ldl -ltinfo
-_curses_panel _curses_panel.c -I/usr/include/ncursesw -DHAVE_NCURSESW -lpanelw -lncursesw -lpanelw -lncursesw -ltinfo -ldl -lncursesw -ltinfo -ldl -ltinfo -lncursesw -ltinfo -ldl -ltinfo
-_crypt _cryptmodule.c -lcrypt
+_curses_panel _curses_panel.c -I/usr/include/ncursesw -DHAVE_NCURSESW -lpanelw -lncursesw -lpanelw -lncursesw -ltinfo -ldl -ltinfo -lncursesw -ltinfo -ldl -lncursesw -ltinfo -ldl -ltinfo
 _socket socketmodule.c
 _ssl _ssl.c -lssl -lcrypto
 _hashlib _hashopenssl.c -lssl -lcrypto
@@ -55,8 +51,6 @@ _dbm _dbmmodule.c -DHAVE_BERKDB_H -DDB_DBM_HSEARCH -ldb-5.3
 _gdbm _gdbmmodule.c -lgdbm
 termios termios.c
 resource resource.c
-ossaudiodev ossaudiodev.c
-nis nismodule.c -lnsl
 zlib zlibmodule.c -lz
 binascii binascii.c -DUSE_ZLIB_CRC32 -lz
 _bz2 _bz2module.c -lbz2

--- a/gen-setup.py
+++ b/gen-setup.py
@@ -23,6 +23,10 @@ BLACKLIST = {
     '_sqlite3',  # https://bugs.python.org/issue37839
     '_tkinter',  # conflicts around expat, will come back to it
 
+    # PEP 594 ("Removing dead batteries from the standard library")
+    # recommends removing these.
+    # https://www.python.org/dev/peps/pep-0594/
+    'spwd', 'parser', 'audioop', '_crypt', 'ossaudiodev', 'nis'
 }
 
 # Make defaultdict subclass that defaults to getting stuff from pkg-config

--- a/test-imports.py
+++ b/test-imports.py
@@ -7,7 +7,7 @@ import subprocess
 import binascii
 import mmap
 import math
-import parser
+# import parser # See https://github.com/pyz-dispenser/cpython-static/pull/1
 import readline
 import resource
 import termios

--- a/test-imports.py
+++ b/test-imports.py
@@ -15,7 +15,7 @@ import termios
 # Use a native module
 import bz2
 import contextvars
-import crypt
+# import crypt # See https://github.com/pyz-dispenser/cpython-static/pull/1
 import csv
 import ctypes
 import curses


### PR DESCRIPTION
PEP 594 ("Removing dead batteries from the standard library") recommends
removing a certain collection of modules. Any of those which were in
Setup.local are removed by this commit.

https://www.python.org/dev/peps/pep-0594/

Removed modules:

- `spwd`
- `parser`
- `audioop`
- `_crypt`
- `ossaudiodev`
- `nis`

The rest were not referenced in `Setup.local`, and thus are left alone.

Note, however, that removing `_crypt` but not `crypt` means you can still `import crypt` and get an `ImportError`:

```
/home/puppy/dev/python/pyz-dispenser/x # PYTHONPATH=./stdlib.zip ./python
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Python 3.8.0 (tags/v3.8.0:fa919fd, Feb  7 2020, 02:19:56) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import crypt
Traceback (most recent call last):
  File "/home/puppy/dev/python/pyz-dispenser/x/stdlib.zip/crypt.py", line 6, in <module>
ModuleNotFoundError: No module named '_crypt'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<frozen zipimport>", line 259, in load_module
  File "/home/puppy/dev/python/pyz-dispenser/x/stdlib.zip/crypt.py", line 11, in <module>
ImportError: The required _crypt module was not built as part of CPython
>>> 
```

